### PR TITLE
Updated the config.yml to reflect new name

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,13 +1,13 @@
 #document settings
 title: Federal Spending Transparency 
 desc: "Open Data Policy — Managing Information as an Asset"
-url: //project-open-data.github.io/
-repo_name: project-open-data.github.io
+url: //fmdatatransparency.github.io/
+repo_name: fmdatatransparency.github.io
 branch: master
 
 #global settings, no need to change these
-root_url: //project-open-data.github.io
-org_name: project-open-data
+root_url: //fmdatatransparency.github.io
+org_name: fmdatatransparency
 
 # default build settings for running locally, no need to edit
 pymgemnts: true


### PR DESCRIPTION
I added a few more changes to set the sitewide url to fmdatatransparency.github.io. This should trigger a rebuild of the site so it shows up and fix the styling issues we were seeing.
