### PR TITLE
point mailchimp links to the secure signup form

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -46,7 +46,7 @@
                   <li><a href="/dataelements">Data Elements</a></li>
                   <li><a href="/data-exchange-standard">Data Exchange</a></li>
                   <li><a href="https://github.com/{{ site.org_name }}/{{ site.repo_name }}/issues">Discuss</a></li>
-                  <li><a href="http://eepurl.com/bgqOH9">Get Updates</a></lis>
+                  <li><a href="https://gsa.us9.list-manage.com/subscribe?u=6f1977de9eff4c384dc8d6527&id=5cee0e93aa">Get Updates</a></lis>
                 </ul>
               </div><!--/.nav-collapse -->
             </div>

--- a/feedback.md
+++ b/feedback.md
@@ -38,4 +38,4 @@ Each three-week interval will have its own milestone, or deadline. Once a milest
 
 Because of this, it’s important to stay informed of the milestones and which issues will be closing soon. You may find it helpful to prioritize those elements whose issues will be closed in the near future. Please note that the team working on the spending standard is very small. Gathering feedback in three-week intervals will allow them to fully engage with your feedback.
 
-You can get updates when new data elements are ready for feedback by [joining our mailing list](http://eepurl.com/bgqOH9).
+You can get updates when new data elements are ready for feedback by [joining our mailing list](https://gsa.us9.list-manage.com/subscribe?u=6f1977de9eff4c384dc8d6527&id=5cee0e93aa).

--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ Because there are so many data elements, we’ll be focusing the conversation on
 
 The feedback on the data exchange standard will be open on a less regular, but still rolling basis. As newly defined elements are added to the schema and we create example implementations, we will post new versions to collect feedback on.  
 
-To get updates on when any new information is posted to this space, please [sign up for our email list](http://eepurl.com/bgqOH9).
+To get updates on when any new information is posted to this space, please [sign up for our email list](https://gsa.us9.list-manage.com/subscribe?u=6f1977de9eff4c384dc8d6527&id=5cee0e93aa).
 
 ##How to Participate
 


### PR DESCRIPTION
Explicitly use the https link instead of the shortened URL provided by MailChimp, which goes to the non-https form.